### PR TITLE
fix(ui): Print no-migrations message on empty status

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -341,12 +341,21 @@ async fn status(config: &Config) -> anyhow::Result<()> {
 
     let zipped = status.full_status();
 
-    let rows = zipped.values().cloned().map(|v| MigrationStatus {
-        id: v.id.into(),
-        name: v.name,
-        run_at: v.run_at,
-        directory: v.directory,
-    });
+    let rows: Vec<_> = zipped
+        .values()
+        .cloned()
+        .map(|v| MigrationStatus {
+            id: v.id.into(),
+            name: v.name,
+            run_at: v.run_at,
+            directory: v.directory,
+        })
+        .collect();
+
+    if rows.is_empty() {
+        println!("No migrations to show");
+        return Ok(());
+    }
 
     print_table(rows);
     Ok(())


### PR DESCRIPTION
The output of `status` in the empty state (without any migrations available on disk or applied in the database) looks incomplete because it still prints the header divider.

This changes the command to print a special message instead of the table in that case.

Before:

    $ squill status
    ┌────┬──────┬────────┬───────────┐
    │ id │ name │ run_at │ directory │
    ├────┼──────┼────────┼───────────┤

After:

    $ squill status
    No migrations to show
