### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project uses [Semantic Versioning], and is currently in a pre-release state
 ## [0.8.0](https://github.com/jdkaplan/squill/compare/v0.7.0...v0.8.0) - 2024-02-27
 
 ### Fixed
-- *(ui)* Print no-migrations message on empty status ([#147](https://github.com/jdkaplan/squill/pull/147))
+- Print no-migrations message on empty status ([#147](https://github.com/jdkaplan/squill/pull/147))
 - Fix typo in init.up.sql comment ([#146](https://github.com/jdkaplan/squill/pull/146))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,8 @@ This project uses [Semantic Versioning], and is currently in a pre-release state
 - *(ui)* Print no-migrations message on empty status ([#147](https://github.com/jdkaplan/squill/pull/147))
 - Fix typo in init.up.sql comment ([#146](https://github.com/jdkaplan/squill/pull/146))
 
-### Other
-- *(deps)* [**breaking**] Switch from native-tls to rustls ([#149](https://github.com/jdkaplan/squill/pull/149))
-- Generate third-party license texts in dist packages ([#145](https://github.com/jdkaplan/squill/pull/145))
+### Changed
+- Switch from native-tls to rustls ([#149](https://github.com/jdkaplan/squill/pull/149))
 
 ## [0.7.0](https://github.com/jdkaplan/squill/compare/v0.6.0...v0.7.0) - 2024-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project uses [Semantic Versioning], and is currently in a pre-release state
 
 ## Unreleased
 
+## [0.8.0](https://github.com/jdkaplan/squill/compare/v0.7.0...v0.8.0) - 2024-02-27
+
+### Fixed
+- *(ui)* Print no-migrations message on empty status ([#147](https://github.com/jdkaplan/squill/pull/147))
+- Fix typo in init.up.sql comment ([#146](https://github.com/jdkaplan/squill/pull/146))
+
+### Other
+- *(deps)* [**breaking**] Switch from native-tls to rustls ([#149](https://github.com/jdkaplan/squill/pull/149))
+- Generate third-party license texts in dist packages ([#145](https://github.com/jdkaplan/squill/pull/145))
+
 ## [0.7.0](https://github.com/jdkaplan/squill/compare/v0.6.0...v0.7.0) - 2024-02-23
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "squill"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squill"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Database migrations for PostgreSQL"


### PR DESCRIPTION
## 🤖 New release
* `squill`: 0.7.0 -> 0.8.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/jdkaplan/squill/compare/v0.7.0...v0.8.0) - 2024-02-27

### Fixed
- *(ui)* Print no-migrations message on empty status ([#147](https://github.com/jdkaplan/squill/pull/147))
- Fix typo in init.up.sql comment ([#146](https://github.com/jdkaplan/squill/pull/146))

### Other
- *(deps)* [**breaking**] Switch from native-tls to rustls ([#149](https://github.com/jdkaplan/squill/pull/149))
- Generate third-party license texts in dist packages ([#145](https://github.com/jdkaplan/squill/pull/145))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).