### PR TITLE
chore: release 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "squill"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "squill-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/squill-cli/CHANGELOG.md
+++ b/squill-cli/CHANGELOG.md
@@ -9,26 +9,13 @@ This project uses [Semantic Versioning], and is currently in a pre-release state
 
 ## Unreleased
 
-## [0.8.0](https://github.com/jdkaplan/squill/releases/tag/squill-cli-v0.8.0) - 2024-06-27
+## [0.9.0](https://github.com/jdkaplan/squill/compare/v0.8.0...squill-cli-v0.9.0) - 2024-06-27
 
 ### Added
-- [**breaking**] Add named migration templates
-
-### Fixed
-- fix!(bin): `renumber --write` -> `align-ids --execute`
+- Add named migration templates
 
 ### Other
-- Fork changelog for separate packages
 - [**breaking**] Split into bin and lib packages
-- Recommend cargo add to install library
-- squill v0.5.1 ([#63](https://github.com/jdkaplan/squill/pull/63))
-- Prepare v0.5.0 release
-- Release v0.4.2
-- Add instructions for using the new library crate
-- Update install instructions
-- drift -> squill
-- "Release" v0.2.0
-- Rewrite it in Rust
 
 ## [0.8.0](https://github.com/jdkaplan/squill/compare/v0.7.0...v0.8.0) - 2024-02-27
 

--- a/squill-cli/CHANGELOG.md
+++ b/squill-cli/CHANGELOG.md
@@ -9,6 +9,27 @@ This project uses [Semantic Versioning], and is currently in a pre-release state
 
 ## Unreleased
 
+## [0.8.0](https://github.com/jdkaplan/squill/releases/tag/squill-cli-v0.8.0) - 2024-06-27
+
+### Added
+- [**breaking**] Add named migration templates
+
+### Fixed
+- fix!(bin): `renumber --write` -> `align-ids --execute`
+
+### Other
+- Fork changelog for separate packages
+- [**breaking**] Split into bin and lib packages
+- Recommend cargo add to install library
+- squill v0.5.1 ([#63](https://github.com/jdkaplan/squill/pull/63))
+- Prepare v0.5.0 release
+- Release v0.4.2
+- Add instructions for using the new library crate
+- Update install instructions
+- drift -> squill
+- "Release" v0.2.0
+- Rewrite it in Rust
+
 ## [0.8.0](https://github.com/jdkaplan/squill/compare/v0.7.0...v0.8.0) - 2024-02-27
 
 ### Fixed

--- a/squill-cli/Cargo.toml
+++ b/squill-cli/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1.0.78"
 clap = { version = "4.4.12", features = ["derive"] }
 figment = { version = "0.10.13", features = ["env", "toml"] }
 serde = { version = "1.0.196", features = ["derive"] }
-squill = { version = "=0.8.0", path = "../squill" }
+squill = { version = "=0.9.0", path = "../squill" }
 sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "postgres", "time", "uuid"] }
 tabled = "0.15.0"
 time = { version = "0.3.32", features = ["formatting", "serde"] }

--- a/squill-cli/Cargo.toml
+++ b/squill-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squill-cli"
-version = "0.8.0"
+version = "0.9.0"
 description = "Command-line tool for PostgreSQL database migrations"
 
 edition.workspace = true

--- a/squill/CHANGELOG.md
+++ b/squill/CHANGELOG.md
@@ -9,14 +9,12 @@ This project uses [Semantic Versioning], and is currently in a pre-release state
 
 ## Unreleased
 
-## [0.9.0](https://github.com/jdkaplan/squill/compare/squill-v0.8.0...squill-v0.9.0) - 2024-06-27
+## [0.9.0](https://github.com/jdkaplan/squill/compare/v0.8.0...squill-v0.9.0) - 2024-06-27
 
 ### Added
 - [**breaking**] Add named migration templates
 
 ### Other
-- Build static templates in bulk
-- Fork changelog for separate packages
 - [**breaking**] Split into bin and lib packages
 
 ## [0.8.0](https://github.com/jdkaplan/squill/compare/v0.7.0...v0.8.0) - 2024-02-27

--- a/squill/CHANGELOG.md
+++ b/squill/CHANGELOG.md
@@ -9,6 +9,16 @@ This project uses [Semantic Versioning], and is currently in a pre-release state
 
 ## Unreleased
 
+## [0.9.0](https://github.com/jdkaplan/squill/compare/squill-v0.8.0...squill-v0.9.0) - 2024-06-27
+
+### Added
+- [**breaking**] Add named migration templates
+
+### Other
+- Build static templates in bulk
+- Fork changelog for separate packages
+- [**breaking**] Split into bin and lib packages
+
 ## [0.8.0](https://github.com/jdkaplan/squill/compare/v0.7.0...v0.8.0) - 2024-02-27
 
 ### Fixed

--- a/squill/Cargo.toml
+++ b/squill/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squill"
-version = "0.8.0"
+version = "0.9.0"
 description = "Manage PostgreSQL database migrations"
 
 edition.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `squill`: 0.8.0 -> 0.9.0
* `squill-cli`: 0.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `squill`
<blockquote>

## [0.9.0](https://github.com/jdkaplan/squill/compare/squill-v0.8.0...squill-v0.9.0) - 2024-06-27

### Added
- [**breaking**] Add named migration templates

### Other
- Build static templates in bulk
- Fork changelog for separate packages
- [**breaking**] Split into bin and lib packages
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).