### PR TITLE
ci: Run checks with latest stable Rust

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,3 +63,35 @@ jobs:
           PGPASSWORD: 'password'
           PGHOST: 'localhost'
           PGPORT: '5432'
+
+  msrv:
+    name: Minimum Supported Rust Version
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.70
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo test --package squill --no-fail-fast
+        env:
+          PGUSER: 'postgres'
+          PGPASSWORD: 'password'
+          PGHOST: 'localhost'
+          PGPORT: '5432'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
The released binary will be compiled with the latest stable Rust version, so CI
should run checks on it. The library can then define a minimum supported Rust
version (MSRV), and CI can ensure that compatibility.
