### PR TITLE
build(deps): Remove unused dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1684,7 +1683,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid",
  "webpki-roots",
 ]
 
@@ -1768,7 +1766,6 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "uuid",
  "whoami",
 ]
 
@@ -1809,7 +1806,6 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "uuid",
  "whoami",
 ]
 
@@ -1835,7 +1831,6 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "uuid",
 ]
 
 [[package]]
@@ -1866,11 +1861,9 @@ dependencies = [
  "sqlx",
  "squill",
  "tabled",
- "tempfile",
  "time",
  "tokio",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -2325,7 +2318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
- "serde",
 ]
 
 [[package]]

--- a/squill-cli/Cargo.toml
+++ b/squill-cli/Cargo.toml
@@ -24,13 +24,9 @@ anyhow = "1.0.78"
 clap = { version = "4.4.12", features = ["derive"] }
 figment = { version = "0.10.13", features = ["env", "toml"] }
 serde = { version = "1.0.203", features = ["derive"] }
+sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls"] }
 squill = { version = "=0.9.0", path = "../squill" }
-sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "postgres", "time", "uuid"] }
 tabled = "0.15.0"
-time = { version = "0.3.36", features = ["formatting", "serde"] }
+time = "0.3.36"
 tokio = { version = "1.35.1", features = ["full"] }
 tracing-subscriber = "0.3.18"
-
-[dev-dependencies]
-tempfile = "3.5.0"
-uuid = { version = "1.6.1", features = ["v4", "serde"] }

--- a/squill/Cargo.toml
+++ b/squill/Cargo.toml
@@ -18,14 +18,15 @@ include = [
 [dependencies]
 lazy_static = "1.4.0"
 regex = "1.10.3"
-sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "postgres", "time", "uuid"] }
+sqlx = { version = "0.7.3", features = ["postgres", "time"] }
 tera = { version = "1.19.1", default-features = false }
 thiserror = "1.0.57"
-time = { version = "0.3.36", features = ["formatting", "serde"] }
-tokio = { version = "1.35.1", features = ["full"] }
+time = "0.3.36"
 tracing = "0.1.40"
 
 [dev-dependencies]
 anyhow = "1.0.78"
+sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls"] }
 tempfile = "3.5.0"
-uuid = { version = "1.6.1", features = ["v4", "serde"] }
+tokio = { version = "1.35.1", features = ["full"] }
+uuid = { version = "1.6.1", features = ["v4"] }


### PR DESCRIPTION
Now that the bin and lib are split, it's possible to shrink their dependencies down a bit.
