### PR TITLE
ci: Remove MSRV test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,35 +63,3 @@ jobs:
           PGPASSWORD: 'password'
           PGHOST: 'localhost'
           PGPORT: '5432'
-
-  msrv:
-    name: Minimum Supported Rust Version
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@1.70
-
-      - uses: Swatinem/rust-cache@v2
-
-      - run: cargo test --package squill --no-fail-fast
-        env:
-          PGUSER: 'postgres'
-          PGPASSWORD: 'password'
-          PGHOST: 'localhost'
-          PGPORT: '5432'


### PR DESCRIPTION
This project depends on `sqlx`, which loosely tracks Rust stable without declaring a minimum supported Rust version (MSRV).

So, since there's no need to declare an MSRV for Squill, reuse the same policy: test on stable, try not to use new features too quickly.
